### PR TITLE
Fix broken URL displayed on https://bioconductor.org/help/docker/ .

### DIFF
--- a/content/help/docker.md
+++ b/content/help/docker.md
@@ -35,7 +35,7 @@ release and devel versions of Bioconductor, and (probably, eventually)
 some older versions.
 
 Bioconductor's Docker images are stored in
-[Docker Hub](https://registry.hub.docker.com/repos/bioconductor/);
+[Docker Hub](https://hub.docker.com/u/bioconductor/);
 the source Dockerfiles are in
 [Github](https://github.com/Bioconductor/bioc_docker).
 


### PR DESCRIPTION
Fixes https://github.com/Bioconductor/bioconductor.org/issues/24 .
